### PR TITLE
Fix unsupported browser issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "slacky",
   "version": "0.0.6",
   "description": "Slack wrapper for Linux arm64 systems",
-  "main": "dist/app/app.js",
+  "main": "dist/app/src/app.js",
   "scripts": {
     "start": "electron .",
     "build": "swc src -d dist/app",

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ export default class Main {
   
     Main.mainWindow.loadURL(SLACK_APP_URL, {
       // TODO: Fix this hacky way to get around Slack's user agent check
-      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/53/7.36 (KHTML, like Gecko) HeadlessChrome/135.0.7049.95 Safari/537.36'
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.3'
     })
    
     Main.mainWindow.on('closed', Main.onClose)


### PR DESCRIPTION
User agent provided by: https://www.useragents.me/

I don't really like the fact that the user-agent is hardcoded but it works
maybe in the future to integrate it directly basing from https://github.com/DavideViolante/useragents-me-api/?
(it's unofficial and basically doing web scraping, you could copy paste it so removing an extra dependency)


Closes https://github.com/andirsun/Slacky/issues/30