### PR TITLE
fix: bump Chrome version in user agent to fix browser deprecation warning

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, shell, Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse } from 'electron'
 import enhanceWebRequest from 'electron-better-web-request'
 
-const defaultUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36'
+const defaultUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
 
 const enhanceSession = (session: Session) => {
   enhanceWebRequest(session)


### PR DESCRIPTION
## Summary

Fixes #46

Slack is showing a 'This browser won't be supported starting May 18th, 2026' warning because the Chrome version in our User Agent string is outdated.

## Change

Updated `defaultUserAgent` in `src/main.ts`:

```
- Chrome/138.0.0.0
+ Chrome/142.0.0.0
```

## Rationale

- Electron 39 bundles Chromium 142
- Chrome 142 satisfies Slack's browser requirements past the May 18th, 2026 deprecation deadline
- This follows the same fix pattern as PR #36 which resolved the previous deprecation warning

## Testing

The `defaultUserAgent` constant is used in both:
1. `session.setUserAgent()` / `onBeforeSendHeaders` handler
2. The `loadURL()` call's userAgent option

Both are covered by this single change.