### PR TITLE
feat: focus the window when a Slack notification is clicked

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,3 @@
+export enum SlackyEvent {
+  NotificationClicked = 'slacky:notification-clicked',
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { BrowserWindow, shell, Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse, ipcMain } from 'electron'
 import enhanceWebRequest from 'electron-better-web-request'
 import * as path from 'path'
+import { SlackyEvent } from './events'
 
 const defaultUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
 
@@ -113,7 +114,7 @@ export default class Main {
     Main.application.on('window-all-closed', Main.onWindowAllClosed)
     Main.application.on('ready', Main.onReady)
 
-    ipcMain.on('slacky:notification-clicked', Main.onNotificationClicked)
+    ipcMain.on(SlackyEvent.NotificationClicked, Main.onNotificationClicked)
 
     Main.application.on('session-created', (session) => {
       enhanceSession(session)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
-import { BrowserWindow, shell, Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse } from 'electron'
+import { BrowserWindow, shell, Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse, ipcMain } from 'electron'
 import enhanceWebRequest from 'electron-better-web-request'
+import * as path from 'path'
 
 const defaultUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36'
 
@@ -45,8 +46,14 @@ export default class Main {
       autoHideMenuBar: true,
       center: true,
       webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: true
+        // contextIsolation must be off so the preload can patch the same
+        // `window.Notification` that Slack's page scripts use. nodeIntegration
+        // stays off so the remote Slack code still gets no Node access; the
+        // preload keeps Node/IPC privileges via its own closure.
+        contextIsolation: false,
+        nodeIntegration: false,
+        sandbox: false,
+        preload: path.join(__dirname, 'preload.js')
       }
     })
 
@@ -78,7 +85,26 @@ export default class Main {
       userAgent: defaultUserAgent,
     })
    
+    // Stop flashing the taskbar entry once the window is actually focused.
+    Main.mainWindow.on('focus', () => Main.mainWindow?.flashFrame(false))
+
     Main.mainWindow.on('closed', Main.onClose)
+  }
+
+  /**
+   * Bring the Slacky window back to the foreground. Triggered from the preload
+   * when a Slack notification is clicked. On Linux (especially Wayland) the
+   * compositor may refuse to let an app raise itself, so we restore + show +
+   * focus and fall back to flashing the taskbar entry as an urgency hint.
+   */
+  private static onNotificationClicked() {
+    const win = Main.mainWindow
+    if (!win) return
+
+    if (win.isMinimized()) win.restore()
+    win.show()
+    win.focus()
+    win.flashFrame(true)
   }
 
   static main(app: Electron.App, browserWindow: typeof BrowserWindow) {
@@ -86,6 +112,8 @@ export default class Main {
     Main.application = app
     Main.application.on('window-all-closed', Main.onWindowAllClosed)
     Main.application.on('ready', Main.onReady)
+
+    ipcMain.on('slacky:notification-clicked', Main.onNotificationClicked)
 
     Main.application.on('session-created', (session) => {
       enhanceSession(session)

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,4 +1,5 @@
 import { ipcRenderer } from 'electron'
+import { SlackyEvent } from './events'
 
 /**
  * Slack's web client raises desktop notifications through the HTML5
@@ -22,7 +23,7 @@ if (NativeNotification) {
     construct(target, args: [string, NotificationOptions?]) {
       const notification = new target(...args)
       notification.addEventListener('click', () => {
-        ipcRenderer.send('slacky:notification-clicked')
+        ipcRenderer.send(SlackyEvent.NotificationClicked)
       })
       return notification
     }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,0 +1,30 @@
+import { ipcRenderer } from 'electron'
+
+/**
+ * Slack's web client raises desktop notifications through the HTML5
+ * `window.Notification` API. When the user clicks one, Slack's own handler
+ * calls `window.focus()` — but on Linux that request is routinely ignored by
+ * the window manager for a backgrounded window, so the Slacky window never
+ * comes forward.
+ *
+ * We wrap the `Notification` constructor so that every notification also tells
+ * the main process (which CAN raise the window) when it is clicked. A Proxy on
+ * the `construct` trap is used so all static members (`permission`,
+ * `requestPermission`, etc.) and `instanceof` checks keep working untouched.
+ *
+ * This requires `contextIsolation: false` so the patch lands in the same
+ * JavaScript context that Slack's page scripts read `Notification` from.
+ */
+const NativeNotification = window.Notification
+
+if (NativeNotification) {
+  window.Notification = new Proxy(NativeNotification, {
+    construct(target, args: [string, NotificationOptions?]) {
+      const notification = new target(...args)
+      notification.addEventListener('click', () => {
+        ipcRenderer.send('slacky:notification-clicked')
+      })
+      return notification
+    }
+  })
+}


### PR DESCRIPTION
## Problem

Clicking a Slack desktop notification did nothing — focus never returned to the Slacky window. Slack's web client only calls `window.focus()` on notification click, which Linux window managers routinely ignore for a backgrounded Electron window, and nothing in the main process raised it.

## Fix

- **New `src/preload.ts`** wraps `window.Notification` with a `Proxy` `construct` trap (preserving all statics — `permission`, `requestPermission` — and `instanceof`). Each notification gets a `click` listener that sends `slacky:notification-clicked` over IPC. The listener is *added*, so Slack's own click handler (which navigates to the conversation) still runs.
- **`src/main.ts`** handles that IPC by `restore()` + `show()` + `focus()` on the window, with `flashFrame(true)` as a fallback (cleared on `focus`) since some Wayland compositors refuse to let an app raise itself.

## ⚠️ Security-posture note (please read before reviewing the diff)

This changes `webPreferences` from `contextIsolation: true` to `contextIsolation: false`. This is **required and not a regression in Node exposure**:

- With `contextIsolation: true`, a preload cannot patch the same `Notification` object the page reads (separate JS contexts), and injecting a wrapper into the main world is blocked by Slack's CSP. Disabling it is the only way to patch `Notification` in a wrapper.
- **`nodeIntegration` is also turned off** (it was previously `true`), so remote Slack code still gets **no** Node access. The preload keeps `ipcRenderer` inside a closure and exposes nothing to the page.

So the net Node-exposure posture is unchanged; this is the standard tradeoff for an Electron site wrapper.

## Testing

Verified live on Asahi Linux (aarch64): triggered notifications via Slackbot reminder and a real DM with the window unfocused. Confirmed the notification fires through `window.Notification` (not a service worker), the click event reaches the renderer, IPC fires, the window comes forward, and Slack's own navigation to the conversation is preserved.

## Note

Happy to trim the verbose code comments in the preload/main if you'd prefer a leaner diff — just let me know.

---

_This PR was created with the help of AI tools. I have audited and verified the changes myself._