### PR TITLE
fix: enable screen sharing in huddles and recordings

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,3 +1,4 @@
 export enum SlackyEvent {
   NotificationClicked = 'slacky:notification-clicked',
+  ScreenShareSourceSelected = 'slacky:screen-share-source-selected',
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,59 @@
-import { BrowserWindow, shell, Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse, ipcMain } from 'electron'
+import { BrowserWindow, shell, Session, OnBeforeSendHeadersListenerDetails, BeforeSendResponse, ipcMain, desktopCapturer } from 'electron'
 import * as path from 'path'
 import { SlackyEvent } from './events'
 
 const defaultUserAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36'
+
+const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, (char) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#39;' }[char] as string
+  ))
+
+/**
+ * Build the standalone HTML used by the screen-share picker window. Each
+ * capturable source (screen or window) is embedded directly as a clickable
+ * card — including its thumbnail as a data URL — so the picker renderer needs
+ * no further IPC to populate itself. Clicking a card (or Cancel) sends the
+ * chosen source id (or null) back to the main process.
+ */
+const buildScreenSharePickerHtml = (sources: Electron.DesktopCapturerSource[], channel: string): string => {
+  const cards = sources.map((source) => `
+    <button class="source" data-id="${escapeHtml(source.id)}">
+      <img src="${source.thumbnail.toDataURL()}" alt="">
+      <span title="${escapeHtml(source.name)}">${escapeHtml(source.name)}</span>
+    </button>`).join('')
+
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 20px; background: #1a1d21; color: #e8e8e8; }
+  h1 { font-size: 18px; margin: 0 0 16px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
+  .source { display: flex; flex-direction: column; gap: 8px; padding: 8px; background: #222529; border: 2px solid transparent; border-radius: 8px; cursor: pointer; color: inherit; text-align: left; }
+  .source:hover { border-color: #1264a3; background: #2a2e33; }
+  .source img { width: 100%; height: 124px; object-fit: cover; background: #000; border-radius: 4px; }
+  .source span { font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .actions { margin-top: 20px; text-align: right; }
+  #cancel { padding: 8px 18px; font-size: 14px; border-radius: 6px; border: 1px solid #4a4f55; background: transparent; color: inherit; cursor: pointer; }
+  #cancel:hover { background: #2a2e33; }
+</style>
+</head>
+<body>
+  <h1>Choose what to share</h1>
+  <div class="grid">${cards}</div>
+  <div class="actions"><button id="cancel">Cancel</button></div>
+  <script>
+    const { ipcRenderer } = require('electron')
+    document.querySelectorAll('.source').forEach((el) => {
+      el.addEventListener('click', () => ipcRenderer.send('${channel}', el.dataset.id))
+    })
+    document.getElementById('cancel').addEventListener('click', () => ipcRenderer.send('${channel}', null))
+  </script>
+</body>
+</html>`
+}
 
 const enhanceSession = (session: Session) => {
   session.setUserAgent(defaultUserAgent)
@@ -80,6 +131,19 @@ export default class Main {
       return { action: 'allow' }
     })
 
+    /**
+     * Slack's huddle/recording "share screen" button calls
+     * `navigator.mediaDevices.getDisplayMedia()`. Without a display-media
+     * request handler Electron silently drops that request, so the button does
+     * nothing and Slack reports `content-share-connectivity=Failed`. We answer
+     * the request by letting the user pick a screen or window.
+     */
+    Main.mainWindow.webContents.session.setDisplayMediaRequestHandler((_request, callback) => {
+      Main.pickScreenShareSource()
+        .then((source) => callback(source ? { video: source } : {}))
+        .catch(() => callback({}))
+    })
+
     Main.mainWindow.loadURL(SLACK_APP_URL, {
       userAgent: defaultUserAgent,
     })
@@ -104,6 +168,54 @@ export default class Main {
     win.show()
     win.focus()
     win.flashFrame(true)
+  }
+
+  /**
+   * Enumerate the available screens/windows and let the user choose one in a
+   * small modal picker. Resolves with the chosen source, or null if there is
+   * nothing to capture or the user cancels. (On Wayland, capture goes through
+   * the xdg-desktop-portal, which may surface its own picker as well.)
+   */
+  private static pickScreenShareSource(): Promise<Electron.DesktopCapturerSource | null> {
+    return desktopCapturer
+      .getSources({ types: ['screen', 'window'], thumbnailSize: { width: 320, height: 180 } })
+      .then((sources) => {
+        if (sources.length === 0) return null
+
+        return new Promise<Electron.DesktopCapturerSource | null>((resolve) => {
+          const picker = new BrowserWindow({
+            parent: Main.mainWindow ?? undefined,
+            modal: true,
+            width: 760,
+            height: 600,
+            title: 'Choose what to share',
+            autoHideMenuBar: true,
+            webPreferences: {
+              contextIsolation: false,
+              nodeIntegration: true,
+              sandbox: false,
+            },
+          })
+
+          let settled = false
+          const finish = (id: string | null) => {
+            if (settled) return
+            settled = true
+            ipcMain.removeListener(SlackyEvent.ScreenShareSourceSelected, onSelected)
+            const chosen = id ? sources.find((source) => source.id === id) ?? null : null
+            if (!picker.isDestroyed()) picker.close()
+            resolve(chosen)
+          }
+          const onSelected = (_event: Electron.IpcMainEvent, id: string | null) => finish(id)
+
+          ipcMain.on(SlackyEvent.ScreenShareSourceSelected, onSelected)
+          // Closing the window (e.g. via the title bar) counts as a cancel.
+          picker.on('closed', () => finish(null))
+
+          const html = buildScreenSharePickerHtml(sources, SlackyEvent.ScreenShareSourceSelected)
+          picker.loadURL('data:text/html;charset=utf-8,' + encodeURIComponent(html))
+        })
+      })
   }
 
   static main(app: Electron.App, browserWindow: typeof BrowserWindow) {


### PR DESCRIPTION
## Summary

Fixes screen sharing, which did nothing when clicked during huddles/recordings and caused Slack to report `content-share-connectivity=Failed`.

The root cause: Slack's "share screen" button calls `navigator.mediaDevices.getDisplayMedia()`, but since Electron 17 that request is **silently dropped** unless the main process registers a [`setDisplayMediaRequestHandler`](https://www.electronjs.org/docs/latest/api/session#sessetdisplaymediarequesthandlerhandler-opts). The app had no such handler, so the request had nowhere to go. Mic and camera worked because `getUserMedia` is granted by default — screen capture was the only thing gated behind the missing handler, which matches the diagnostic in the issue (`audio-input`/`video-input`/`camera` all succeed, only `content-share-connectivity` fails).

## Changes

- Register `setDisplayMediaRequestHandler` on the Slack window's session (`src/main.ts`).
- Add a small modal **source picker**, built from `desktopCapturer.getSources`, so the user can choose a screen or specific window to share (thumbnails embedded inline; no build-pipeline change needed).
- Cancelling or closing the picker cleanly aborts the capture request.
- Add a `ScreenShareSourceSelected` IPC event (`src/events.ts`).

## Testing

- `npm run build` passes (swc).
- New code is type-clean.

> [!IMPORTANT]
> I could not test actual screen capture from my environment (no Linux/Wayland aarch64 hardware). The reporter is on **Fedora Asahi / Wayland**, where capture goes through PipeWire + `xdg-desktop-portal`. On Wayland the portal may surface its own picker in addition to ours. Please verify on the target hardware before merging — ideally with @adewaleafolabi, who filed the issue.

Fixes #37