### PR TITLE
fix: allow huddle pop-out windows to open natively

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,39 @@ const enhanceSession = (session: Session) => {
   )
 }
 
+/**
+ * A URL is "external" only when it is a real http(s) link that does not belong
+ * to Slack. Internal targets — most importantly `about:blank`, which Slack uses
+ * when it pops a huddle out via `window.open()` and then drives the returned
+ * window itself — must stay inside Electron.
+ */
+const isExternalUrl = (url: string): boolean =>
+  /^https?:\/\//i.test(url) && !url.includes('slack.com')
+
+/**
+ * Route genuinely external links to the system browser while letting Slack's
+ * own windows (slack.com pages and the `about:blank` huddle pop-out) open as
+ * native Electron windows. Denying the pop-out used to make `window.open()`
+ * return null, which Slack reported as "Unable to create window".
+ */
+const applyExternalLinkPolicy = (contents: Electron.WebContents) => {
+  contents.setWindowOpenHandler(({ url }) => {
+    if (isExternalUrl(url)) {
+      shell.openExternal(url)
+      return { action: 'deny' } // Deny Electron from opening new windows directly
+    }
+    return { action: 'allow' }
+  })
+
+  // Intercept in-page navigation; keep external links in the OS browser.
+  contents.on('will-navigate', (event, url) => {
+    if (isExternalUrl(url)) {
+      event.preventDefault()
+      shell.openExternal(url)
+    }
+  })
+}
+
 export default class Main {
   static mainWindow: Electron.BrowserWindow | null
   static application: Electron.App
@@ -56,28 +89,15 @@ export default class Main {
       }
     })
 
-    /**
-     * Open links in the default browser except for slack.com operations.
-     */
-    Main.mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-      if (url.includes('slack.com')) {
-        // Open if URL belongs to slack.com
-        return { action: 'allow' }
-      } else {
-        // Open external links in the system's default browser
-        shell.openExternal(url)
-        return { action: 'deny' } // Deny Electron from opening new windows directly
-      }
-    })
+    // Keep external links in the OS browser; let Slack's own windows
+    // (including the about:blank huddle pop-out) open natively.
+    applyExternalLinkPolicy(Main.mainWindow.webContents)
 
-    // Intercept link navigation within the page
-    Main.mainWindow.webContents.on('will-navigate', (event, url) => {
-      if (!url.includes('slack.com')) {
-        event.preventDefault() // Prevent navigation
-        shell.openExternal(url) // Open in external OS browser
-        return { action: 'deny' }
-      }
-      return { action: 'allow' }
+    // Apply the same policy to windows Slack opens (e.g. the popped-out huddle)
+    // so links clicked inside them still go to the OS browser.
+    Main.mainWindow.webContents.on('did-create-window', (childWindow) => {
+      childWindow.setMenuBarVisibility(false)
+      applyExternalLinkPolicy(childWindow.webContents)
     })
 
     Main.mainWindow.loadURL(SLACK_APP_URL, {


### PR DESCRIPTION
## Summary

Fixes popping a huddle out into its own window, which instead opened an `about:blank` tab in the system browser and logged `"Attempted to window.open but received falsey return value"` / `"Unable to create window"`.

**Root cause:** Slack pops the huddle out by calling `window.open('about:blank')` and then driving the returned window itself. Our `setWindowOpenHandler` allowed only URLs containing `slack.com` and sent everything else — including `about:blank` — to `shell.openExternal` with `{ action: 'deny' }`. Denying made `window.open()` return `null`, which is exactly the error Slack reports. The earlier "external windows" patch only covered `slack.com` URLs, so the `about:blank` pop-out still fell through.

## Changes (`src/main.ts`)

- Add an `isExternalUrl()` helper: a URL is external only if it's a real `http(s)` link **and** not `slack.com`. `about:blank` and slack.com windows stay internal.
- Extract an `applyExternalLinkPolicy()` helper used for both the window-open handler and `will-navigate`; only genuinely external links are handed to the OS browser, everything else opens as a native Electron window.
- Apply the same policy to windows Slack creates (via `did-create-window`) so links clicked inside a popped-out huddle still open in the browser.
- Fix the `will-navigate` guard, which previously blocked **any** non-`slack.com` navigation (same flawed logic as the open handler).

## Testing

- `npm run build` passes (swc).
- New code is type-clean.

> [!IMPORTANT]
> I could not test huddle pop-out from my environment (no Linux/aarch64 + live Slack huddle). Please verify on the target setup before merging — @uorbe001 offered to help debug in the issue thread and is comfortable with the JS dev tools.

Fixes #39