### PR TITLE
fix: keep Google SSO inside Slacky

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,12 +20,23 @@ const enhanceSession = (session: Session) => {
 
 /**
  * A URL is "external" only when it is a real http(s) link that does not belong
- * to Slack. Internal targets — most importantly `about:blank`, which Slack uses
- * when it pops a huddle out via `window.open()` and then drives the returned
- * window itself — must stay inside Electron.
+ * to Slack or a supported authentication provider. Internal targets — most
+ * importantly `about:blank`, which Slack uses when it pops a huddle out via
+ * `window.open()` and then drives the returned window itself — must stay inside
+ * Electron.
  */
-const isExternalUrl = (url: string): boolean =>
-  /^https?:\/\//i.test(url) && !url.includes('slack.com')
+const isExternalUrl = (url: string): boolean => {
+  if (!/^https?:\/\//i.test(url)) return false
+
+  try {
+    const { hostname } = new URL(url)
+    const isSlack = hostname === 'slack.com' || hostname.endsWith('.slack.com')
+    const isGoogleAuth = hostname === 'accounts.google.com'
+    return !isSlack && !isGoogleAuth
+  } catch {
+    return true
+  }
+}
 
 /**
  * Route genuinely external links to the system browser while letting Slack's


### PR DESCRIPTION
## Summary

- keep `accounts.google.com` authentication pages inside Slacky's Electron session
- continue opening unrelated external links in the system browser
- match Slack hosts by parsed hostname instead of substring

## Why

Google SSO currently opens in the external browser because Slacky classifies every non-Slack HTTPS URL as external. That separates the authentication page from Slacky's Electron session and prevents sign-in from completing in the app.

The authentication flow was reproduced on Ubuntu ARM64 and verified end-to-end with this change: Google sign-in completed and the workspace opened in Slacky.

## Testing

- `npm run lint`
- `npm run build`
- `git diff --check`
- manual Google SSO sign-in on Ubuntu ARM64

Fixes #48
